### PR TITLE
Skip graphql column generation for BLOB type.

### DIFF
--- a/src/GraphQLTypeGenerator.php
+++ b/src/GraphQLTypeGenerator.php
@@ -283,7 +283,7 @@ EOF;
         }
         return $thisVariableName;
     }
-
+k
 
 EOF;
 

--- a/src/GraphQLTypeGenerator.php
+++ b/src/GraphQLTypeGenerator.php
@@ -270,7 +270,7 @@ EOF;
         $type = $this->getType($descriptor);
 
         if ($type === null) {
-            return "    // Field $getterName is ignored. Cannot represent a JSON field in GraphQL.";
+            return "    // Field $getterName is ignored. Cannot represent a JSON  or BLOB field in GraphQL.";
         }
 
         $code = <<<EOF
@@ -283,7 +283,6 @@ EOF;
         }
         return $thisVariableName;
     }
-k
 
 EOF;
 
@@ -300,8 +299,8 @@ EOF;
 
         $phpType = $descriptor->getPhpType();
         if ($descriptor instanceof ScalarBeanPropertyDescriptor) {
-            if ($phpType === 'array') {
-                // JSON type cannot be casted since GraphQL does not allow for untyped arrays.
+            if ($phpType === 'array' || $phpType === 'resource') {
+                // JSON and BLOB type cannot be casted since GraphQL does not allow for untyped arrays or BLOB.
                 return null;
             }
 
@@ -314,7 +313,7 @@ EOF;
             ];
 
             if (!isset($map[$phpType])) {
-                throw new GraphQLGeneratorNamespaceException("Cannot map PHP type '$phpType' to any known GraphQL type.");
+                throw new GraphQLGeneratorNamespaceException("Cannot map PHP type '$phpType' to any known GraphQL type in table '{$descriptor->getTable()->getName()}' for column '{$descriptor->getColumnName()}'.");
             }
 
             $newCode = 'new '.$map[$phpType].'()';


### PR DESCRIPTION
If column type is JSON or BLOB, the generation is skipped.
Error message for unknown type is now displaying table and column name.