### PR TITLE
Fix code generation for fields with BLOB types

### DIFF
--- a/src/GraphQLTypeGenerator.php
+++ b/src/GraphQLTypeGenerator.php
@@ -252,8 +252,8 @@ EOF;
     {
         if ($descriptor instanceof ScalarBeanPropertyDescriptor) {
             $phpType = $descriptor->getPhpType();
-            if ($phpType === 'array') {
-                // JSON type cannot be casted since GraphQL does not allow for untyped arrays.
+            if ($phpType === 'array' || $phpType === 'resource') {
+                // JSON or BLOB types cannot be casted since GraphQL does not allow for untyped arrays or BLOB.
                 return false;
             }
         }

--- a/src/GraphQLTypeGenerator.php
+++ b/src/GraphQLTypeGenerator.php
@@ -270,7 +270,10 @@ EOF;
         $type = $this->getType($descriptor);
 
         if ($type === null) {
-            return "    // Field $getterName is ignored. Cannot represent a JSON  or BLOB field in GraphQL.";
+            return <<<EOF
+    // Field $getterName is ignored. Cannot represent a JSON  or BLOB field in GraphQL.
+
+EOF;
         }
 
         $code = <<<EOF


### PR DESCRIPTION
When my table contains a field with type BLOB, moreover followed by other supported fields, the code generated is wrong.

1) The next property declaration is part of the comment
Before:
```php
    // Field getChanges is ignored. Cannot represent a JSON  or BLOB field in GraphQL.    private $createDateField;
        
    protected function getCreateDateField() : Field
    {
```
 So I added a carriage return to avoid that.
After:
```php
    // Field getChanges is ignored. Cannot represent a JSON  or BLOB field in GraphQL.
    private $createDateField;
        
    protected function getCreateDateField() : Field
    {
```
2) In the method getFieldList() only type JSON was checked, so my BLOB type still was in the list.
Before:
```php
    /**
     * @return Field[]
     */
    protected function getFieldList(): array
    {
        return array_merge(parent::getFieldList(), [
            $this->getIdManageProductsChangesField(),
            $this->getMemberField(),
            $this->getChangesField(),
            $this->getCreateDateField(),
        ]);
    }
```
I added a check on the BLOB type to remove the field from the list
After:
```php
    /**
     * @return Field[]
     */
    protected function getFieldList(): array
    {
        return array_merge(parent::getFieldList(), [
            $this->getIdManageProductsChangesField(),
            $this->getMemberField(),
            $this->getCreateDateField(),
        ]);
    }
```