### PR TITLE
Add a middleware wrapper to  NoBeanFoundException

### DIFF
--- a/src/Middlewares/NoBeanFoundExceptionWrapperMiddleware.php
+++ b/src/Middlewares/NoBeanFoundExceptionWrapperMiddleware.php
@@ -10,10 +10,8 @@ use TheCodingMachine\TDBM\NoBeanFoundException;
 
 class NoBeanFoundExceptionWrapperMiddleware implements FieldMiddlewareInterface
 {
-
     public function process(QueryFieldDescriptor $queryFieldDescriptor, FieldHandlerInterface $fieldHandler): ?FieldDefinition
     {
-
         $resolver = $queryFieldDescriptor->getResolver();
 
         $queryFieldDescriptor->setResolver(function (...$args) use ($resolver, $queryFieldDescriptor) {

--- a/src/Middlewares/NoBeanFoundExceptionWrapperMiddleware.php
+++ b/src/Middlewares/NoBeanFoundExceptionWrapperMiddleware.php
@@ -1,0 +1,39 @@
+<?php
+namespace TheCodingMachine\Tdbm\GraphQL\Middlewares;
+
+use GraphQL\Type\Definition\FieldDefinition;
+use TheCodingMachine\GraphQLite\Exceptions\GraphQLException;
+use TheCodingMachine\GraphQLite\Middlewares\FieldHandlerInterface;
+use TheCodingMachine\GraphQLite\Middlewares\FieldMiddlewareInterface;
+use TheCodingMachine\GraphQLite\QueryFieldDescriptor;
+use TheCodingMachine\TDBM\NoBeanFoundException;
+
+class NoBeanFoundExceptionWrapperMiddleware implements FieldMiddlewareInterface
+{
+
+    public function process(QueryFieldDescriptor $queryFieldDescriptor, FieldHandlerInterface $fieldHandler): ?FieldDefinition
+    {
+
+        $resolver = $queryFieldDescriptor->getResolver();
+
+        $queryFieldDescriptor->setResolver(function (...$args) use ($resolver, $queryFieldDescriptor) {
+            try {
+                return $resolver(...$args);
+            } catch (NoBeanFoundException $e) {
+                throw new GraphQLException(
+                    $e->getMessage(),
+                    404,
+                    $e,
+                    'Exception',
+                    [
+                        'table' => $e->getTableName(),
+                        'keys' => $e->getPrimaryKeys(),
+                        'className' => $e->getClassName()
+                    ]
+                );
+            }
+        });
+
+        return $fieldHandler->handle($queryFieldDescriptor);
+    }
+}


### PR DESCRIPTION
Adds the `NoBeanFoundExceptionWrapperMiddleware` that allows catching TDBM's `NoBeanFoundException` [(https://github.com/thecodingmachine/tdbm/blob/master/src/NoBeanFoundException.php)](https://github.com/thecodingmachine/tdbm/blob/master/src/NoBeanFoundException.php) and wrapp it into a GraphQLite exception for better error handling